### PR TITLE
Asset Bundle Parser

### DIFF
--- a/LethalAPI.Core/Loader/PluginLoader.cs
+++ b/LethalAPI.Core/Loader/PluginLoader.cs
@@ -76,6 +76,7 @@ public sealed class PluginLoader
         // Ensure that these are registered by loading the reference.
         _ = new UnknownResourceParser();
         _ = new DllParser();
+        _ = new BundleParser();
 
         // Instance is stored in the type.
         _ = new EmbeddedResourceLoader();

--- a/LethalAPI.Core/Loader/PluginLoader.cs
+++ b/LethalAPI.Core/Loader/PluginLoader.cs
@@ -76,7 +76,7 @@ public sealed class PluginLoader
         // Ensure that these are registered by loading the reference.
         _ = new UnknownResourceParser();
         _ = new DllParser();
-        _ = new BundleParser();
+        _ = new AssetBundleParser();
 
         // Instance is stored in the type.
         _ = new EmbeddedResourceLoader();

--- a/LethalAPI.Core/Loader/Resources/AssetBundleParser.cs
+++ b/LethalAPI.Core/Loader/Resources/AssetBundleParser.cs
@@ -7,7 +7,90 @@
 
 namespace LethalAPI.Core.Loader.Resources;
 
-public class AssetBundleParser
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+
+using JetBrains.Annotations;
+using UnityEngine;
+
+/// <inheritdoc />
+public class AssetBundleParser : ResourceParser
 {
-    
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AssetBundleParser"/> class.
+    /// </summary>
+    internal AssetBundleParser()
+    {
+        Instance = this;
+    }
+
+    /// <summary>
+    /// Gets the instance of this resource parser.
+    /// </summary>
+    public static ResourceParser Instance { get; private set; } = null!;
+
+    /// <summary>
+    /// Gets a list of all cached asset bundles by name.
+    /// </summary>
+    /// <example>
+    /// MyBundle.bundle -> CachedBundles[MyBundle].
+    /// </example>
+    public static Dictionary<string, AssetBundle> CachedBundles => new ();
+
+    /// <inheritdoc />
+    public override string ExtensionName => "bundle";
+
+    /// <summary>
+    /// Tries to get an asset bundle from the embedded bundles.
+    /// </summary>
+    /// <param name="name">The name of the bundle.</param>
+    /// <param name="bundle">The returned bundle.</param>
+    /// <returns>True if the bundle was found, false if the bundle could not be found.</returns>
+    public static bool TryGetBundle(string name, [NotNullWhen(true)] out AssetBundle? bundle)
+    {
+        bundle = null;
+        if (CachedBundles.ContainsKey(name))
+        {
+            bundle = CachedBundles[name];
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Gets a cached asset resource.
+    /// </summary>
+    /// <param name="assetName">The name of the asset.</param>
+    /// <param name="bundleName">The name of the bundle (optional).</param>
+    /// <typeparam name="T">The type of resource to get.</typeparam>
+    /// <returns>The asset resource if found. Null if not found.</returns>
+    public static T? GetResource<T>(string assetName, string bundleName = "")
+        where T : Object
+    {
+        if (bundleName != string.Empty && !CachedBundles.ContainsKey(bundleName))
+            return null;
+
+        List<AssetBundle> bundles = bundleName == string.Empty ? CachedBundles.Values.ToList() : new() { CachedBundles[bundleName] };
+        foreach (AssetBundle bundle in bundles)
+        {
+            return bundle.LoadAsset<T>(assetName);
+        }
+
+        return null;
+    }
+
+    /// <inheritdoc />
+    public override object Parse(MemoryStream stream)
+    {
+        return AssetBundle.LoadFromStream(stream);
+    }
+
+    /// <inheritdoc />
+    public override void ResourceFound(EmbeddedResourceData resourceData)
+    {
+        CachedBundles.Add(resourceData.FileName.Replace(".bundle", string.Empty), (AssetBundle)Parse(resourceData.GetStream()));
+    }
 }

--- a/LethalAPI.Core/Loader/Resources/AssetBundleParser.cs
+++ b/LethalAPI.Core/Loader/Resources/AssetBundleParser.cs
@@ -1,0 +1,13 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="AssetBundleParser.cs" company="LethalAPI Modding Community">
+// Copyright (c) LethalAPI Modding Community. All rights reserved.
+// Licensed under the LGPL-3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace LethalAPI.Core.Loader.Resources;
+
+public class AssetBundleParser
+{
+    
+}


### PR DESCRIPTION
It is simple but allows for the quick loading of asset bundles as [file].bundle files from the embedded resource stream.